### PR TITLE
Fix canonical title map utility

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,22 +34,14 @@ var enumToTitleMap = function enumToTitleMap(enm) {
 // Takes a titleMap in either object or list format and returns one in
 // in the list format.
 var canonicalTitleMap = function canonicalTitleMap(titleMap, originalEnum) {
-    if (!_lodash2.default.isArray(titleMap)) {
-        var canonical = [];
-        if (originalEnum) {
-            originalEnum.forEach(function (value) {
-                canonical.push({ name: titleMap[value], value: value });
-            });
-        } else {
-            for (var k in titleMap) {
-                if (titleMap.hasOwnProperty(k)) {
-                    canonical.push({ name: k, value: titleMap[k] });
-                }
-            }
-        }
-        return canonical;
-    }
-    return titleMap;
+    if (!originalEnum) return titleMap;
+
+    var canonical = [];
+    var _enum = Object.keys(titleMap).length == 0 ? originalEnum : titleMap;
+    originalEnum.forEach(function (value, idx) {
+        canonical.push({ name: _enum[idx], value: value });
+    });
+    return canonical;
 };
 
 //Creates a form object with all common properties

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import _ from'lodash';
+import _ from 'lodash';
 import ObjectPath from 'objectpath';
 import tv4 from 'tv4';
 
@@ -24,22 +24,15 @@ var enumToTitleMap = function(enm) {
 // Takes a titleMap in either object or list format and returns one in
 // in the list format.
 var canonicalTitleMap = function(titleMap, originalEnum) {
-    if (!_.isArray(titleMap)) {
-        var canonical = [];
-        if (originalEnum) {
-            originalEnum.forEach(function(value) {
-                canonical.push({name: titleMap[value], value: value});
-            });
-        } else {
-            for(var k in titleMap) {
-                if (titleMap.hasOwnProperty(k)) {
-                    canonical.push({name: k, value: titleMap[k]});
-                }
-            }
-        }
-        return canonical;
-    }
-    return titleMap;
+    if (!originalEnum)
+        return titleMap;
+
+    const canonical = [];
+    const _enum = (Object.keys(titleMap).length == 0)? originalEnum : titleMap;
+    originalEnum.forEach(function (value, idx) {
+        canonical.push({ name: _enum[idx], value: value });
+    });
+    return canonical;
 };
 
 //Creates a form object with all common properties


### PR DESCRIPTION
# Canonical Title map simplification

It returns the canonical representation of the provided `titleMap` in a simple way, independently of if we're using a dict / key:value based mapping (`form.titleMap` object) or a sorted list map (`enumNames` array).

It also provides support for `enumNames` schema definition. Empty mappings are also handled.

Fix #86 enumNames are not resolved

### Tested scenarios

```
const schema = {
    "type": "object",
    "title": "An schema",
    "properties": {
        "owner": {
            "type": "object",
            "title": "A title",
            "required": [],
            "properties": {
                "language": {
                  "title": "Language with form titleMap",
                  "type": "string",
                  "enum": [
                    "ca_ES",
                    "es_ES"
                  ]
                },
                "language2": {
                  "title": "Language with enumNames",
                  "type": "string",
                  "enum": [
                    "ca_ES",
                    "es_ES"
                  ],
                  "enumNames": [
                    "cat",
                    "cast"
                  ]
                },
                "language3": {
                  "title": "Language without mapping",
                  "type": "string",
                  "enum": [
                    "ca_ES",
                    "es_ES"
                  ]
                }
            }
        },
        "required": []
    }
}


const form = [
    {
      "key": "owner.language",
      "titleMap": [
            {
                "value": "ca_ES",
                "name": "Català"
            },
            {
                "value": "es_ES",
                "name": "Castellano"
            }
        ]
    },
    "owner.language2",
    "owner.language3"
]

```

