### PR TITLE
Identify all SchemaForm fields by an unique key based on their form.key

### DIFF
--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -48,10 +48,13 @@ class SchemaForm extends React.Component {
           console.log('Invalid field: \"' + form.key[0] + '\"!');
           return null;
         }
+
         if(form.condition && eval(form.condition) === false) {
           return null;
         }
-        return <Field model={model} form={form} key={index} onChange={onChange} mapper={mapper} builder={this.builder}/>
+
+        const key = form.key && form.key.join(".") || index;
+        return <Field model={model} form={form} key={key} onChange={onChange} mapper={mapper} builder={this.builder}/>
     }
 
     render() {


### PR DESCRIPTION
The form.key is an array, this is joined using dots.

If the `form.key` is not provided, it uses the ordinal index instead.