### PR TITLE
Safe form conditions evaluation #91

### DIFF
--- a/lib/SchemaForm.js
+++ b/lib/SchemaForm.js
@@ -106,7 +106,7 @@ var SchemaForm = function (_React$Component) {
                 console.log('Invalid field: \"' + form.key[0] + '\"!');
                 return null;
             }
-            if (form.condition && eval(form.condition) === false) {
+            if (form.condition && _utils2.default.safeEval(form.condition, { model: model }) === false) {
                 return null;
             }
             return _react2.default.createElement(Field, { model: model, form: form, key: index, onChange: onChange, mapper: mapper, builder: this.builder });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,17 @@ var _tv = require('tv4');
 
 var _tv2 = _interopRequireDefault(_tv);
 
+var _notevil = require('notevil');
+
+var _notevil2 = _interopRequireDefault(_notevil);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+//Evaluates an expression in a safe way
+function safeEval(condition, scope) {
+    var scope_safe = _lodash2.default.cloneDeep(scope);
+    return (0, _notevil2.default)(condition, scope_safe);
+}
 
 function stripNullType(type) {
     if (Array.isArray(type) && type.length == 2) {
@@ -627,6 +637,7 @@ module.exports = {
     merge: merge,
     validate: validate,
     validateBySchema: validateBySchema,
+    safeEval: safeEval,
     selectOrSet: selectOrSet
 };
 ;
@@ -635,6 +646,8 @@ var _temp = function () {
     if (typeof __REACT_HOT_LOADER__ === 'undefined') {
         return;
     }
+
+    __REACT_HOT_LOADER__.register(safeEval, 'safeEval', 'src/utils.js');
 
     __REACT_HOT_LOADER__.register(stripNullType, 'stripNullType', 'src/utils.js');
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,8 +20,12 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 //Evaluates an expression in a safe way
 function safeEval(condition, scope) {
-    var scope_safe = _lodash2.default.cloneDeep(scope);
-    return (0, _notevil2.default)(condition, scope_safe);
+    try {
+        var scope_safe = _lodash2.default.cloneDeep(scope);
+        return (0, _notevil2.default)(condition, scope_safe);
+    } catch (error) {
+        return undefined;
+    }
 }
 
 function stripNullType(type) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "classnames": "^2.2.5",
     "lodash": "^4.16.6",
     "objectpath": "^1.2.1",
-    "tv4": "^1.2.7"
+    "tv4": "^1.2.7",
+    "notevil": "^1.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -48,7 +48,7 @@ class SchemaForm extends React.Component {
           console.log('Invalid field: \"' + form.key[0] + '\"!');
           return null;
         }
-        if(form.condition && eval(form.condition) === false) {
+        if(form.condition && utils.safeEval(form.condition, {model}) === false) {
           return null;
         }
         return <Field model={model} form={form} key={index} onChange={onChange} mapper={mapper} builder={this.builder}/>

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,13 @@
 import _ from'lodash';
 import ObjectPath from 'objectpath';
 import tv4 from 'tv4';
+import notevil from 'notevil';
+
+//Evaluates an expression in a safe way
+function safeEval(condition, scope) {
+    const scope_safe = _.cloneDeep(scope);
+    return notevil(condition, scope_safe);
+}
 
 function stripNullType(type) {
     if (Array.isArray(type) && type.length == 2) {
@@ -607,5 +614,6 @@ module.exports = {
     merge: merge,
     validate: validate,
     validateBySchema: validateBySchema,
+    safeEval: safeEval,
     selectOrSet: selectOrSet
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,8 +5,12 @@ import notevil from 'notevil';
 
 //Evaluates an expression in a safe way
 function safeEval(condition, scope) {
-    const scope_safe = _.cloneDeep(scope);
-    return notevil(condition, scope_safe);
+    try {
+        const scope_safe = _.cloneDeep(scope);
+        return notevil(condition, scope_safe);
+    } catch (error) {
+        return undefined
+    }
 }
 
 function stripNullType(type) {


### PR DESCRIPTION
It evaluates an expression in a safe way

It uses `notevil` lib to create an evalutaion sandbox based on the passed scope.

The model is passed as {model: model} to preserve the key inside the evaluation sandbox.

If an exception is raised while evaluating the condition it returns `undefined` "passing" the accomplishment of the conditional due to the field will not render only when the condition is strictly false. 

Related to #90