### PR TITLE
Autocomplete field

### DIFF
--- a/lib/SchemaForm.js
+++ b/lib/SchemaForm.js
@@ -22,6 +22,10 @@ var _TextArea = require('./TextArea');
 
 var _TextArea2 = _interopRequireDefault(_TextArea);
 
+var _TextSuggest = require('./TextSuggest');
+
+var _TextSuggest2 = _interopRequireDefault(_TextSuggest);
+
 var _Select = require('./Select');
 
 var _Select2 = _interopRequireDefault(_Select);
@@ -78,6 +82,7 @@ var SchemaForm = function (_React$Component) {
             'text': _Text2.default,
             'password': _Text2.default,
             'textarea': _TextArea2.default,
+            'textsuggest': _TextSuggest2.default,
             'select': _Select2.default,
             'radios': _Radios2.default,
             'date': _Date2.default,

--- a/lib/TextSuggest.js
+++ b/lib/TextSuggest.js
@@ -1,0 +1,157 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _ComposedComponent = require('./ComposedComponent');
+
+var _ComposedComponent2 = _interopRequireDefault(_ComposedComponent);
+
+var _AutoComplete = require('material-ui/AutoComplete');
+
+var _AutoComplete2 = _interopRequireDefault(_AutoComplete);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; } /**
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                * Created by XaviTorello on 30/05/18
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                */
+
+
+var dataSourceConfig = {
+    text: 'name',
+    value: 'value'
+};
+
+var TextSuggest = function (_React$Component) {
+    _inherits(TextSuggest, _React$Component);
+
+    function TextSuggest() {
+        var _ref;
+
+        var _temp, _this, _ret;
+
+        _classCallCheck(this, TextSuggest);
+
+        for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
+            args[_key] = arguments[_key];
+        }
+
+        return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = TextSuggest.__proto__ || Object.getPrototypeOf(TextSuggest)).call.apply(_ref, [this].concat(args))), _this), _this.handleUpdate = function () {
+            var _this2;
+
+            return (_this2 = _this).__handleUpdate__REACT_HOT_LOADER__.apply(_this2, arguments);
+        }, _this.handleInit = function () {
+            var _this3;
+
+            return (_this3 = _this).__handleInit__REACT_HOT_LOADER__.apply(_this3, arguments);
+        }, _temp), _possibleConstructorReturn(_this, _ret);
+    }
+
+    _createClass(TextSuggest, [{
+        key: '__handleInit__REACT_HOT_LOADER__',
+        value: function __handleInit__REACT_HOT_LOADER__() {
+            return this.__handleInit__REACT_HOT_LOADER__.apply(this, arguments);
+        }
+    }, {
+        key: '__handleUpdate__REACT_HOT_LOADER__',
+        value: function __handleUpdate__REACT_HOT_LOADER__() {
+            return this.__handleUpdate__REACT_HOT_LOADER__.apply(this, arguments);
+        }
+    }, {
+        key: '__handleUpdate__REACT_HOT_LOADER__',
+        value: function __handleUpdate__REACT_HOT_LOADER__(newValue, index) {
+            var key = this.props.form.key;
+            var type = this.props.form.schema.type;
+
+            return this.props.onChange(key, newValue[dataSourceConfig['value']], type);
+        }
+    }, {
+        key: '__handleInit__REACT_HOT_LOADER__',
+        value: function __handleInit__REACT_HOT_LOADER__(init_value) {
+            if (!this.props.form.schema || !this.props.form.schema.enum) return init_value.toString();
+
+            var names = this.props.form.schema.enumNames || this.props.form.schema.enum;
+            var values = this.props.form.schema.enum;
+
+            console.log(names, values);
+            console.log("indexOf", values.indexOf(init_value));
+            console.log("names[values.indexOf(init_value)]", names[values.indexOf(init_value)]);
+            var init_value_name = names[values.indexOf(init_value)];
+
+            // this.handleUpdate({[dataSourceConfig['value']]: init_value, [dataSourceConfig['text']]: init_value_name})
+
+            return init_value_name || init_value.toString();
+        }
+    }, {
+        key: 'render',
+        value: function render() {
+            // console.log('TextSuggest', this.props);
+            // assign the filter, by default case insensitive
+            var filter = function (filter) {
+                switch (filter) {
+                    case 'fuzzy':
+                        return _AutoComplete2.default.fuzzyFilter;
+                        break;
+                    default:
+                        return _AutoComplete2.default.caseInsensitiveFilter;
+                        break;
+                }
+            }(this.props.form.filter);
+
+            var value = this.props.value && this.handleInit(this.props.value);
+
+            return _react2.default.createElement(
+                'div',
+                { className: this.props.form.htmlClass },
+                _react2.default.createElement(_AutoComplete2.default, {
+                    type: this.props.form.type,
+                    floatingLabelText: this.props.form.title,
+                    hintText: this.props.form.placeholder,
+                    errorText: this.props.error,
+                    onNewRequest: this.handleUpdate,
+                    disabled: this.props.form.readonly,
+                    style: this.props.form.style || { width: '100%' },
+                    openOnFocus: true,
+                    searchText: value,
+                    dataSource: this.props.form.titleMap || ['Loading...'],
+                    filter: filter,
+                    maxSearchResults: this.props.form.maxSearchResults || 5,
+                    dataSourceConfig: dataSourceConfig
+                })
+            );
+        }
+    }]);
+
+    return TextSuggest;
+}(_react2.default.Component);
+
+var _default = (0, _ComposedComponent2.default)(TextSuggest);
+
+exports.default = _default;
+;
+
+var _temp2 = function () {
+    if (typeof __REACT_HOT_LOADER__ === 'undefined') {
+        return;
+    }
+
+    __REACT_HOT_LOADER__.register(dataSourceConfig, 'dataSourceConfig', 'src/TextSuggest.js');
+
+    __REACT_HOT_LOADER__.register(TextSuggest, 'TextSuggest', 'src/TextSuggest.js');
+
+    __REACT_HOT_LOADER__.register(_default, 'default', 'src/TextSuggest.js');
+}();
+
+;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "classnames": "^2.2.5",
     "lodash": "^4.16.6",
     "objectpath": "^1.2.1",
+    "react-autosuggest": "^9.3.4",
     "tv4": "^1.2.7"
   },
   "devDependencies": {

--- a/src/SchemaForm.js
+++ b/src/SchemaForm.js
@@ -6,6 +6,7 @@ import utils from './utils';
 import Number from './Number';
 import Text from './Text';
 import TextArea from './TextArea';
+import TextSuggest from './TextSuggest';
 import Select from './Select';
 import Radios from './Radios';
 import Date from './Date';
@@ -22,6 +23,7 @@ class SchemaForm extends React.Component {
         'text': Text,
         'password': Text,
         'textarea': TextArea,
+        'textsuggest': TextSuggest,
         'select': Select,
         'radios': Radios,
         'date': Date,

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -14,8 +14,25 @@ class TextSuggest extends React.Component {
     handleUpdate = (newValue, index) => {
       const {key} = this.props.form
       const {type} = this.props.form.schema
-      this.props.onChange(key, newValue[dataSourceConfig['value']], type)
+      return this.props.onChange(key, newValue[dataSourceConfig['value']], type)
     };
+
+    handleInit = (init_value) => {
+        if (!this.props.form.schema || !this.props.form.schema.enum)
+            return init_value.toString()
+
+        const names = this.props.form.schema.enumNames || this.props.form.schema.enum;
+        const values = this.props.form.schema.enum;
+
+        console.log(names, values);
+        console.log("indexOf", values.indexOf(init_value));
+        console.log("names[values.indexOf(init_value)]", names[values.indexOf(init_value)]);
+        const init_value_name = names[values.indexOf(init_value)];
+
+        // this.handleUpdate({[dataSourceConfig['value']]: init_value, [dataSourceConfig['text']]: init_value_name})
+
+        return init_value_name || init_value.toString()
+    }
 
     render() {
         // console.log('TextSuggest', this.props);

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -14,7 +14,7 @@ class TextSuggest extends React.Component {
     handleUpdate = (newValue, index) => {
       const {key} = this.props.form
       const {type} = this.props.form.schema
-      return this.props.onChange(key, newValue[dataSourceConfig['value']], type)
+      return this.props.onChange(key, newValue[dataSourceConfig['value']], type, this.props.form)
     };
 
     handleInit = (init_value) => {
@@ -24,9 +24,9 @@ class TextSuggest extends React.Component {
         const names = this.props.form.schema.enumNames || this.props.form.schema.enum;
         const values = this.props.form.schema.enum;
 
-        console.log(names, values);
-        console.log("indexOf", values.indexOf(init_value));
-        console.log("names[values.indexOf(init_value)]", names[values.indexOf(init_value)]);
+        // console.log(names, values);
+        // console.log("indexOf", values.indexOf(init_value));
+        // console.log("names[values.indexOf(init_value)]", names[values.indexOf(init_value)]);
         const init_value_name = names[values.indexOf(init_value)];
 
         // this.handleUpdate({[dataSourceConfig['value']]: init_value, [dataSourceConfig['text']]: init_value_name})
@@ -47,6 +47,8 @@ class TextSuggest extends React.Component {
                     break;
             }
         })(this.props.form.filter)
+
+        // console.log("TEXTSUG", this.props);
 
         const value = this.props.value && this.handleInit(this.props.value);
 

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -40,10 +40,11 @@ class TextSuggest extends React.Component {
                     defaultValue={this.props.value}
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '100%'}}
-                    dataSource={datasource}
                     openOnFocus={true}
+                    dataSource={this.props.form.titleMap || ['Loading...']}
                     filter={filter}
                     maxSearchResults={this.props.form.maxSearchResults || 5}
+                    dataSourceConfig={dataSourceConfig}
                 />
             </div>
         );

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -12,7 +12,6 @@ const dataSourceConfig = {
 
 class TextSuggest extends React.Component {
     handleUpdate = (newValue, index) => {
-      console.log("changing", newValue, index);
       const {key} = this.props.form
       const {type} = this.props.form.schema
       this.props.onChange(key, newValue[dataSourceConfig['value']], type)

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -48,6 +48,8 @@ class TextSuggest extends React.Component {
             }
         })(this.props.form.filter)
 
+        const value = this.props.value && this.handleInit(this.props.value);
+
         return (
             <div className={this.props.form.htmlClass}>
                 <AutoComplete
@@ -59,6 +61,7 @@ class TextSuggest extends React.Component {
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '100%'}}
                     openOnFocus={true}
+                    searchText={value}
                     dataSource={this.props.form.titleMap || ['Loading...']}
                     filter={filter}
                     maxSearchResults={this.props.form.maxSearchResults || 5}

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -5,6 +5,11 @@ import React from 'react';
 import ComposedComponent from './ComposedComponent';
 import AutoComplete from 'material-ui/AutoComplete';
 
+const dataSourceConfig = {
+  text: 'name',
+  value: 'value',
+};
+
 class TextSuggest extends React.Component {
     render() {
         // console.log('TextSuggest', this.props.form);

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -41,6 +41,7 @@ class TextSuggest extends React.Component {
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '100%'}}
                     dataSource={datasource}
+                    openOnFocus={true}
                     filter={filter}
                     maxSearchResults={this.props.form.maxSearchResults || 5}
                 />

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -1,0 +1,29 @@
+/**
+ * Created by XaviTorello on 30/05/18
+ */
+import React from 'react';
+import ComposedComponent from './ComposedComponent';
+import TextField from 'material-ui/TextField';
+
+class TextSuggest extends React.Component {
+    render() {
+        console.log('TextSuggest', this.props.form);
+        return (
+            <div className={this.props.form.htmlClass}>
+                <TextField
+                    type={this.props.form.type}
+                    floatingLabelText={this.props.form.title}
+                    hintText={this.props.form.placeholder}
+                    errorText={this.props.error}
+                    onChange={this.props.onChangeValidate}
+                    defaultValue={this.props.value}
+                    disabled={this.props.form.readonly}
+                    autoComplete={this.props.form.autoComplete}
+                    style={this.props.form.style || {width: '100%'}}
+                />
+            </div>
+        );
+    }
+}
+
+export default ComposedComponent(TextSuggest);

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -3,14 +3,30 @@
  */
 import React from 'react';
 import ComposedComponent from './ComposedComponent';
-import TextField from 'material-ui/TextField';
+import AutoComplete from 'material-ui/AutoComplete';
 
 class TextSuggest extends React.Component {
     render() {
-        console.log('TextSuggest', this.props.form);
+        // console.log('TextSuggest', this.props.form);
+
+        // assign the source list to autocomplete
+        const datasource = this.props.form.schema.enumNames || this.props.form.schema.enum || ['Loading...'];
+
+        // assign the filter, by default case insensitive
+        const filter = ((filter) => {
+            switch (filter) {
+                case 'fuzzy':
+                    return AutoComplete.fuzzyFilter;
+                    break;
+                default:
+                    return AutoComplete.caseInsensitiveFilter;
+                    break;
+            }
+        })(this.props.form.filter)
+
         return (
             <div className={this.props.form.htmlClass}>
-                <TextField
+                <AutoComplete
                     type={this.props.form.type}
                     floatingLabelText={this.props.form.title}
                     hintText={this.props.form.placeholder}
@@ -18,8 +34,10 @@ class TextSuggest extends React.Component {
                     onChange={this.props.onChangeValidate}
                     defaultValue={this.props.value}
                     disabled={this.props.form.readonly}
-                    autoComplete={this.props.form.autoComplete}
                     style={this.props.form.style || {width: '100%'}}
+                    dataSource={datasource}
+                    filter={filter}
+                    maxSearchResults={this.props.form.maxSearchResults || 5}
                 />
             </div>
         );

--- a/src/TextSuggest.js
+++ b/src/TextSuggest.js
@@ -11,12 +11,15 @@ const dataSourceConfig = {
 };
 
 class TextSuggest extends React.Component {
+    handleUpdate = (newValue, index) => {
+      console.log("changing", newValue, index);
+      const {key} = this.props.form
+      const {type} = this.props.form.schema
+      this.props.onChange(key, newValue[dataSourceConfig['value']], type)
+    };
+
     render() {
-        // console.log('TextSuggest', this.props.form);
-
-        // assign the source list to autocomplete
-        const datasource = this.props.form.schema.enumNames || this.props.form.schema.enum || ['Loading...'];
-
+        // console.log('TextSuggest', this.props);
         // assign the filter, by default case insensitive
         const filter = ((filter) => {
             switch (filter) {
@@ -36,8 +39,7 @@ class TextSuggest extends React.Component {
                     floatingLabelText={this.props.form.title}
                     hintText={this.props.form.placeholder}
                     errorText={this.props.error}
-                    onChange={this.props.onChangeValidate}
-                    defaultValue={this.props.value}
+                    onNewRequest={this.handleUpdate}
                     disabled={this.props.form.readonly}
                     style={this.props.form.style || {width: '100%'}}
                     openOnFocus={true}

--- a/src/utils.js
+++ b/src/utils.js
@@ -402,9 +402,9 @@ function merge(schema, form, ignore, options, readonly) {
             }
         }
 
-        //If it has a titleMap make sure it's a list
+        //If it has a titleMap make sure to update it with latest enum and names
         if (obj.titleMap) {
-            obj.titleMap = canonicalTitleMap(obj.titleMap);
+            obj.titleMap = canonicalTitleMap(obj.schema.enumNames, obj.schema.enum);
         }
 
         //


### PR DESCRIPTION
# TextSuggest component

It provides the `<TextSuggest>` component devised to render a list of elements using a material-ui `Autocomplete`.

![textsuggest](https://user-images.githubusercontent.com/8709244/41395378-c7801172-6fad-11e8-93ae-914d6d7a4de1.png)

The behaviour of this component is very similar to the `<Select>`, it deals with a list of elements and their possible names:

```
schema = {
    ...
    "state": 
        "enum": [
            "first_code",
            "second_code"
        ],
        "enumNames": [
            "first_label",
            "second_label"
        ],
        "title": "This is a title", 
        "type": "string",
        "default": "second_code",
    ],
    ...
}

form = {
    ...
    {
        "key": "state",  
        "type": "textsuggest"
    },
    ...
}
```

Fix #94 Autocomplete component